### PR TITLE
Add .NET 6 JsonNode support

### DIFF
--- a/source/Handlebars.Extension.Test/Handlebars.Extension.Test.csproj
+++ b/source/Handlebars.Extension.Test/Handlebars.Extension.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <ProjectGuid>1956A22F-7B26-4747-8125-7EAC0B94665D</ProjectGuid>
     <RootNamespace>HandlebarsDotNet.Extension.Test</RootNamespace>
@@ -53,7 +53,7 @@
   </ItemGroup>
   
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1' or '$(TargetFramework)'=='netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1' or '$(TargetFramework)'=='netcoreapp3.1' or '$(TargetFramework)'=='net6.0'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
   </ItemGroup>

--- a/source/Handlebars.Extension.Test/Handlebars.Extension.Test.csproj
+++ b/source/Handlebars.Extension.Test/Handlebars.Extension.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <ProjectGuid>1956A22F-7B26-4747-8125-7EAC0B94665D</ProjectGuid>
     <RootNamespace>HandlebarsDotNet.Extension.Test</RootNamespace>
@@ -10,7 +10,7 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <NoWarn>0618;1701</NoWarn>
   </PropertyGroup>
@@ -27,15 +27,15 @@
   <PropertyGroup Condition="'$(TargetFramework)'=='net452'">
     <DefineConstants>$(DefineConstants);netFramework</DefineConstants>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
     <DefineConstants>$(DefineConstants);netcoreapp;netstandard</DefineConstants>
   </PropertyGroup>
-   
+
   <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);netcoreapp;netstandard</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>
@@ -45,23 +45,22 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
-  
+
 
   <ItemGroup Condition="'$(TargetFramework)'=='net46' or '$(TargetFramework)'=='net461' or '$(TargetFramework)'=='net472' or '$(TargetFramework)'=='net452'">
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
   </ItemGroup>
-  
 
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1' or '$(TargetFramework)'=='netcoreapp3.1' or '$(TargetFramework)'=='net6.0'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\Handlebars.Extension\Handlebars.Extension.csproj" />
   </ItemGroup>

--- a/source/Handlebars.Extension.Test/JsonTests.cs
+++ b/source/Handlebars.Extension.Test/JsonTests.cs
@@ -20,9 +20,7 @@ namespace HandlebarsDotNet.Extension.Test
             private readonly List<(IHandlebars, JsonModelFactory)> _data = new List<(IHandlebars, JsonModelFactory)>
             {
                 (Handlebars.Create(new HandlebarsConfiguration().UseJson()), json => JsonDocument.Parse(json)),
-#if NET6_0_OR_GREATER
                 (Handlebars.Create(new HandlebarsConfiguration().UseJson()), json => System.Text.Json.Nodes.JsonNode.Parse(json)),
-#endif
             };
 
             public IEnumerator<object[]> GetEnumerator() => _data.Select(item => new object[] { item.Item1, item.Item2 }).GetEnumerator();

--- a/source/Handlebars.Extension.sln
+++ b/source/Handlebars.Extension.sln
@@ -1,19 +1,18 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26403.3
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34714.143
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E9AC0BCD-C060-4634-BBBB-636167C809B4}"
 	ProjectSection(SolutionItems) = preProject
-		..\README.md = ..\README.md
 		Directory.Build.props = Directory.Build.props
+		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Handlebars.Extension", "Handlebars.Extension\Handlebars.Extension.csproj", "{9822C7B8-7E51-42BC-9A49-72A10491B202}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Handlebars.Extension", "Handlebars.Extension\Handlebars.Extension.csproj", "{25080858-B620-4985-8AEF-E135324081B3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Handlebars.Extension.Test", "Handlebars.Extension.Test\Handlebars.Extension.Test.csproj", "{6BA232A6-8C4D-4C7D-BD75-1844FE9774AF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Handlebars.Extension.Test", "Handlebars.Extension.Test\Handlebars.Extension.Test.csproj", "{1956A22F-7B26-4747-8125-7EAC0B94665D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Handlebars.Extension.Benchmark", "Handlebars.Extension.Benchmark\Handlebars.Extension.Benchmark.csproj", "{B335E9C5-7DD3-416D-89CC-8D48D89DB628}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Handlebars.Extension.Benchmark", "Handlebars.Extension.Benchmark\Handlebars.Extension.Benchmark.csproj", "{95ECC7A5-0A42-4DAF-A546-20522A3F3CF5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,21 +20,24 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{9822C7B8-7E51-42BC-9A49-72A10491B202}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9822C7B8-7E51-42BC-9A49-72A10491B202}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9822C7B8-7E51-42BC-9A49-72A10491B202}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9822C7B8-7E51-42BC-9A49-72A10491B202}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6BA232A6-8C4D-4C7D-BD75-1844FE9774AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6BA232A6-8C4D-4C7D-BD75-1844FE9774AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6BA232A6-8C4D-4C7D-BD75-1844FE9774AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6BA232A6-8C4D-4C7D-BD75-1844FE9774AF}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B335E9C5-7DD3-416D-89CC-8D48D89DB628}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B335E9C5-7DD3-416D-89CC-8D48D89DB628}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B335E9C5-7DD3-416D-89CC-8D48D89DB628}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B335E9C5-7DD3-416D-89CC-8D48D89DB628}.Release|Any CPU.Build.0 = Release|Any CPU
+		{25080858-B620-4985-8AEF-E135324081B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25080858-B620-4985-8AEF-E135324081B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25080858-B620-4985-8AEF-E135324081B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25080858-B620-4985-8AEF-E135324081B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1956A22F-7B26-4747-8125-7EAC0B94665D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1956A22F-7B26-4747-8125-7EAC0B94665D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1956A22F-7B26-4747-8125-7EAC0B94665D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1956A22F-7B26-4747-8125-7EAC0B94665D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{95ECC7A5-0A42-4DAF-A546-20522A3F3CF5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{95ECC7A5-0A42-4DAF-A546-20522A3F3CF5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{95ECC7A5-0A42-4DAF-A546-20522A3F3CF5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{95ECC7A5-0A42-4DAF-A546-20522A3F3CF5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A684E42D-246D-4CF7-B79C-34C49A10B35F}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/source/Handlebars.Extension/CountMemberAliasProvider.JsonNode.cs
+++ b/source/Handlebars.Extension/CountMemberAliasProvider.JsonNode.cs
@@ -1,0 +1,31 @@
+#if NET6_0_OR_GREATER
+
+using System;
+using System.Text.Json.Nodes;
+using HandlebarsDotNet.PathStructure;
+
+namespace HandlebarsDotNet.Extension.Json
+{
+    public partial class CountMemberAliasProvider : IMemberAliasProvider<JsonNode>
+    {
+        public bool TryGetMemberByAlias(JsonNode instance, Type targetType, ChainSegment memberAlias, out object? value)
+        {
+            if (!EqualsIgnoreCase("count", memberAlias) && !EqualsIgnoreCase("length", memberAlias))
+            {
+                value = null;
+                return false;
+            }
+            
+            if (!(instance is JsonArray jsonArray))
+            {
+                value = null;
+                return false;
+            }
+
+            value = jsonArray.Count;
+            return true;
+        }
+    }
+}
+
+#endif

--- a/source/Handlebars.Extension/CountMemberAliasProvider.JsonNode.cs
+++ b/source/Handlebars.Extension/CountMemberAliasProvider.JsonNode.cs
@@ -1,5 +1,3 @@
-#if NET6_0_OR_GREATER
-
 using System;
 using System.Text.Json.Nodes;
 using HandlebarsDotNet.PathStructure;
@@ -15,7 +13,6 @@ namespace HandlebarsDotNet.Extension.Json
                 value = null;
                 return false;
             }
-            
             if (!(instance is JsonArray jsonArray))
             {
                 value = null;
@@ -27,5 +24,3 @@ namespace HandlebarsDotNet.Extension.Json
         }
     }
 }
-
-#endif

--- a/source/Handlebars.Extension/CountMemberAliasProvider.cs
+++ b/source/Handlebars.Extension/CountMemberAliasProvider.cs
@@ -4,7 +4,7 @@ using HandlebarsDotNet.PathStructure;
 
 namespace HandlebarsDotNet.Extension.Json
 {
-    public class CountMemberAliasProvider : IMemberAliasProvider<JsonElement>
+    public partial class CountMemberAliasProvider : IMemberAliasProvider<JsonElement>
     {
         public bool TryGetMemberByAlias(JsonElement instance, Type targetType, ChainSegment memberAlias, out object? value)
         {
@@ -22,11 +22,11 @@ namespace HandlebarsDotNet.Extension.Json
 
             value = instance.GetArrayLength();
             return true;
+        }
 
-            static bool EqualsIgnoreCase(string a, ChainSegment b)
-            {
-                return string.Equals(a, b.TrimmedValue, StringComparison.OrdinalIgnoreCase);
-            }
+        private static bool EqualsIgnoreCase(string a, ChainSegment b)
+        {
+            return string.Equals(a, b.TrimmedValue, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/source/Handlebars.Extension/Handlebars.Extension.csproj
+++ b/source/Handlebars.Extension/Handlebars.Extension.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>HandlebarsDotNet.Extension.Json</AssemblyName>
     <ProjectGuid>25080858-B620-4985-8AEF-E135324081B3</ProjectGuid>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net472</TargetFrameworks>
     <Version>1.0.0</Version>
     <RootNamespace>HandlebarsDotNet.Extension.Json</RootNamespace>

--- a/source/Handlebars.Extension/Handlebars.Extension.csproj
+++ b/source/Handlebars.Extension/Handlebars.Extension.csproj
@@ -10,7 +10,7 @@
     <Nullable>enable</Nullable>
     <SignAssembly Condition="'$(ShouldSignAssembly)' == 'true'">true</SignAssembly>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='netstandard2.1'">
     <DefineConstants>$(DefineConstants);netstandard</DefineConstants>
   </PropertyGroup>
@@ -28,17 +28,17 @@
     <PackageReleaseNotes>https://github.com/Handlebars-Net/Handlebars.Net.Extension.Json/releases/tag/$(Version)</PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="5.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Handlebars.Net" Version="2.0.3" />
   </ItemGroup>
-  
+
 </Project>

--- a/source/Handlebars.Extension/JsonFeature.cs
+++ b/source/Handlebars.Extension/JsonFeature.cs
@@ -10,6 +10,10 @@ namespace HandlebarsDotNet.Extension.Json
         private static readonly JsonDocumentObjectDescriptor JsonDocumentObjectDescriptor = new JsonDocumentObjectDescriptor();
         private static readonly JsonElementObjectDescriptor JsonElementObjectDescriptor = new JsonElementObjectDescriptor();
 
+#if NET6_0_OR_GREATER
+        private static readonly JsonNodeObjectDescriptor JsonNodeObjectDescriptor = new JsonNodeObjectDescriptor();
+#endif
+
         /// <summary>
         /// Adds <see cref="IObjectDescriptorProvider"/>s required to support <c>System.Text.Json</c>. 
         /// </summary>
@@ -21,7 +25,11 @@ namespace HandlebarsDotNet.Extension.Json
             
             providers.Add(JsonDocumentObjectDescriptor);
             providers.Add(JsonElementObjectDescriptor);
-            
+
+#if NET6_0_OR_GREATER
+            providers.Add(JsonNodeObjectDescriptor);
+#endif
+
             return configuration;
         }
     }

--- a/source/Handlebars.Extension/JsonFeature.cs
+++ b/source/Handlebars.Extension/JsonFeature.cs
@@ -3,32 +3,28 @@ using HandlebarsDotNet.ObjectDescriptors;
 namespace HandlebarsDotNet.Extension.Json
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public static class JsonFeatureExtensions
     {
         private static readonly JsonDocumentObjectDescriptor JsonDocumentObjectDescriptor = new JsonDocumentObjectDescriptor();
         private static readonly JsonElementObjectDescriptor JsonElementObjectDescriptor = new JsonElementObjectDescriptor();
 
-#if NET6_0_OR_GREATER
         private static readonly JsonNodeObjectDescriptor JsonNodeObjectDescriptor = new JsonNodeObjectDescriptor();
-#endif
 
         /// <summary>
-        /// Adds <see cref="IObjectDescriptorProvider"/>s required to support <c>System.Text.Json</c>. 
+        /// Adds <see cref="IObjectDescriptorProvider"/>s required to support <c>System.Text.Json</c>.
         /// </summary>
         /// <param name="configuration"></param>
         /// <returns></returns>
         public static HandlebarsConfiguration UseJson(this HandlebarsConfiguration configuration)
         {
             var providers = configuration.ObjectDescriptorProviders;
-            
+
             providers.Add(JsonDocumentObjectDescriptor);
             providers.Add(JsonElementObjectDescriptor);
 
-#if NET6_0_OR_GREATER
             providers.Add(JsonNodeObjectDescriptor);
-#endif
 
             return configuration;
         }

--- a/source/Handlebars.Extension/JsonNodeIterator.cs
+++ b/source/Handlebars.Extension/JsonNodeIterator.cs
@@ -1,0 +1,172 @@
+#if NET6_0_OR_GREATER
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text.Json.Nodes;
+using HandlebarsDotNet.Collections;
+using HandlebarsDotNet.Compiler;
+using HandlebarsDotNet.Iterators;
+using HandlebarsDotNet.PathStructure;
+using HandlebarsDotNet.Runtime;
+using HandlebarsDotNet.ValueProviders;
+
+namespace HandlebarsDotNet.Extension.Json
+{
+    public class JsonNodeIterator : IIterator
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Iterate(
+            in EncodedTextWriter writer,
+            BindingContext context,
+            ChainSegment[] blockParamsVariables,
+            object input,
+            TemplateDelegate template,
+            TemplateDelegate ifEmpty
+        )
+        {
+            Iterate(writer, context, blockParamsVariables, (JsonNode)input, template, ifEmpty);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Iterate(
+            in EncodedTextWriter writer,
+            BindingContext context,
+            ChainSegment[] blockParamsVariables,
+            JsonNode input,
+            TemplateDelegate template,
+            TemplateDelegate ifEmpty
+        )
+        {
+            switch (input)
+            {
+                case JsonObject jsonObject:
+                    IterateObject(writer, context, blockParamsVariables, jsonObject, template, ifEmpty);
+                    break;
+                case JsonArray jsonArray:
+                    IterateArray(writer, context, blockParamsVariables, jsonArray, template, ifEmpty);
+                    break;
+
+                default:
+                    Throw.ArgumentOutOfRangeException();
+                    break;
+            }
+        }
+
+        private static void IterateObject(
+            in EncodedTextWriter writer,
+            BindingContext context,
+            ChainSegment[] blockParamsVariables,
+            JsonObject target,
+            TemplateDelegate template,
+            TemplateDelegate ifEmpty
+        )
+        {
+            using var innerContext = context.CreateFrame();
+            var iterator = new ObjectIteratorValues(innerContext);
+            var blockParamsValues = new BlockParamsValues(innerContext, blockParamsVariables);
+
+            blockParamsValues.CreateProperty(0, out var _0);
+            blockParamsValues.CreateProperty(1, out var _1);
+
+            var enumerator = ExtendedEnumerator<KeyValuePair<string, JsonNode?>>.Create(target.GetEnumerator());
+
+            iterator.First = BoxedValues.True;
+            iterator.Last = BoxedValues.False;
+
+            int index = 0;
+            while (enumerator.MoveNext())
+            {
+                var current = enumerator.Current;
+
+                var currentValue = current.Value;
+                iterator.Key = currentValue.Key;
+
+                if (index == 1) iterator.First = BoxedValues.False;
+                if (current.IsLast) iterator.Last = BoxedValues.True;
+
+                iterator.Index = BoxedValues.Int(index);
+
+                object? resolvedValue = currentValue.Value;
+
+                blockParamsValues[_0] = resolvedValue;
+                blockParamsValues[_1] = currentValue.Key;
+
+                iterator.Value = resolvedValue;
+                innerContext.Value = resolvedValue;
+
+                template(writer, innerContext);
+
+                ++index;
+            }
+
+            if (index == 0)
+            {
+                innerContext.Value = context.Value;
+                ifEmpty(writer, innerContext);
+            }
+        }
+
+        private static void IterateArray(
+            in EncodedTextWriter writer,
+            BindingContext context,
+            ChainSegment[] blockParamsVariables,
+            JsonArray target,
+            TemplateDelegate template,
+            TemplateDelegate ifEmpty
+        )
+        {
+            using var innerContext = context.CreateFrame();
+            var iterator = new IteratorValues(innerContext);
+            var blockParamsValues = new BlockParamsValues(innerContext, blockParamsVariables);
+
+            blockParamsValues.CreateProperty(0, out var _0);
+            blockParamsValues.CreateProperty(1, out var _1);
+
+            iterator.First = BoxedValues.True;
+            iterator.Last = BoxedValues.False;
+
+            var count = target.Count;
+            var enumerator = target.GetEnumerator();
+
+            var index = 0;
+            var lastIndex = count - 1;
+            while (enumerator.MoveNext())
+            {
+                var value = enumerator.Current;
+                var objectIndex = BoxedValues.Int(index);
+
+                if (index == 1) iterator.First = BoxedValues.False;
+                if (index == lastIndex) iterator.Last = BoxedValues.True;
+
+                iterator.Index = objectIndex;
+
+                object? resolvedValue = value;
+
+                blockParamsValues[_0] = resolvedValue;
+                blockParamsValues[_1] = objectIndex;
+
+                iterator.Value = resolvedValue;
+                innerContext.Value = resolvedValue;
+
+                template(writer, innerContext);
+
+                ++index;
+            }
+
+            if (index == 0)
+            {
+                innerContext.Value = context.Value;
+                ifEmpty(writer, innerContext);
+            }
+        }
+
+        private static class Throw
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static void ArgumentOutOfRangeException() => throw new ArgumentOutOfRangeException();
+        }
+    }
+}
+
+#endif

--- a/source/Handlebars.Extension/JsonNodeIterator.cs
+++ b/source/Handlebars.Extension/JsonNodeIterator.cs
@@ -1,5 +1,3 @@
-#if NET6_0_OR_GREATER
-
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -168,5 +166,3 @@ namespace HandlebarsDotNet.Extension.Json
         }
     }
 }
-
-#endif

--- a/source/Handlebars.Extension/JsonNodeMemberAccessor.cs
+++ b/source/Handlebars.Extension/JsonNodeMemberAccessor.cs
@@ -1,0 +1,47 @@
+#if NET6_0_OR_GREATER
+
+using System.Text.Json.Nodes;
+using HandlebarsDotNet.MemberAccessors;
+using HandlebarsDotNet.PathStructure;
+
+namespace HandlebarsDotNet.Extension.Json
+{
+    internal class JsonNodeMemberAccessor : IMemberAccessor
+    {
+        private readonly CountMemberAliasProvider _aliasProvider = new CountMemberAliasProvider();
+
+        public bool TryGetValue(object instance, ChainSegment memberName, out object? value)
+        {
+            var element = (JsonNode)instance;
+
+            if (element is JsonObject jsonObject && jsonObject.TryGetPropertyValue(memberName.TrimmedValue, out var property))
+            {
+                value = Utils.ExtractProperty(property);
+                return true;
+            }
+
+            if (element is JsonArray jsonArray && int.TryParse(memberName, out var index))
+            {
+                if (index >= jsonArray.Count)
+                {
+                    value = null;
+                    return false;
+                }
+
+                var indexedElement = jsonArray[index];
+                value = Utils.ExtractProperty(indexedElement);
+                return true;
+            }
+
+            if (_aliasProvider.TryGetMemberByAlias(element, typeof(JsonNode), memberName, out value))
+            {
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+    }
+}
+
+#endif

--- a/source/Handlebars.Extension/JsonNodeMemberAccessor.cs
+++ b/source/Handlebars.Extension/JsonNodeMemberAccessor.cs
@@ -1,5 +1,3 @@
-#if NET6_0_OR_GREATER
-
 using System.Text.Json.Nodes;
 using HandlebarsDotNet.MemberAccessors;
 using HandlebarsDotNet.PathStructure;
@@ -43,5 +41,3 @@ namespace HandlebarsDotNet.Extension.Json
         }
     }
 }
-
-#endif

--- a/source/Handlebars.Extension/JsonNodeObjectDescriptor.cs
+++ b/source/Handlebars.Extension/JsonNodeObjectDescriptor.cs
@@ -1,0 +1,44 @@
+#if NET6_0_OR_GREATER
+
+using System;
+using System.Collections;
+using System.Text.Json.Nodes;
+using HandlebarsDotNet.ObjectDescriptors;
+
+namespace HandlebarsDotNet.Extension.Json
+{
+    internal class JsonNodeObjectDescriptor : IObjectDescriptorProvider
+    {
+        private static readonly Type Type = typeof(JsonNode);
+
+        private readonly ObjectDescriptor _descriptor = new ObjectDescriptor(
+            Type,
+            JsonDocumentMemberAccessor,
+            (descriptor, instance) => GetEnumerator(instance),
+            self => new JsonNodeIterator()
+        );
+
+        private static readonly JsonNodeMemberAccessor JsonDocumentMemberAccessor = new JsonNodeMemberAccessor();
+
+        public bool TryGetDescriptor(Type type, out ObjectDescriptor value)
+        {
+            if (!Type.IsAssignableFrom(type))
+            {
+                value = ObjectDescriptor.Empty;
+                return false;
+            }
+
+            value = _descriptor;
+            return true;
+        }
+
+        private static IEnumerable GetEnumerator(object instance)
+        {
+            var jsonNode = (JsonNode)instance;
+
+            return Utils.GetEnumerator(jsonNode);
+        }
+    }
+}
+
+#endif

--- a/source/Handlebars.Extension/JsonNodeObjectDescriptor.cs
+++ b/source/Handlebars.Extension/JsonNodeObjectDescriptor.cs
@@ -1,5 +1,3 @@
-#if NET6_0_OR_GREATER
-
 using System;
 using System.Collections;
 using System.Text.Json.Nodes;
@@ -40,5 +38,3 @@ namespace HandlebarsDotNet.Extension.Json
         }
     }
 }
-
-#endif

--- a/source/Handlebars.Extension/Utils.JsonNode.cs
+++ b/source/Handlebars.Extension/Utils.JsonNode.cs
@@ -1,0 +1,48 @@
+#if NET6_0_OR_GREATER
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace HandlebarsDotNet.Extension.Json
+{
+    internal static partial class Utils
+    {
+        public static IEnumerable GetEnumerator(JsonNode jsonNode)
+        {
+            return jsonNode switch
+            {
+                JsonObject jsonObject => EnumerateObject(jsonObject),
+                JsonArray _ => ArrayProperties,
+                _ => Throw.ArgumentOutOfRangeException<IEnumerable>()
+            };
+
+            static IEnumerable<string> EnumerateObject(JsonObject jsonObject)
+            {
+                foreach (var property in jsonObject)
+                {
+                    yield return property.Key;
+                }
+            }
+        }
+
+        public static object? ExtractProperty(JsonNode? property)
+        {
+            if (property == null)
+            {
+                return null;
+            }
+
+            var type = property.GetType();
+            if (type == typeof(JsonObject) || type == typeof(JsonArray))
+            {
+                return property;
+            }
+
+            return ExtractProperty(property.GetValue<JsonElement>());
+        }
+    }
+}
+
+#endif

--- a/source/Handlebars.Extension/Utils.JsonNode.cs
+++ b/source/Handlebars.Extension/Utils.JsonNode.cs
@@ -1,5 +1,3 @@
-#if NET6_0_OR_GREATER
-
 using System.Collections;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -44,5 +42,3 @@ namespace HandlebarsDotNet.Extension.Json
         }
     }
 }
-
-#endif

--- a/source/Handlebars.Extension/Utils.cs
+++ b/source/Handlebars.Extension/Utils.cs
@@ -7,7 +7,7 @@ using HandlebarsDotNet.Runtime;
 
 namespace HandlebarsDotNet.Extension.Json
 {
-    internal static class Utils
+    internal static partial class Utils
     {
         private static readonly string[] ArrayProperties = { "length" };
 


### PR DESCRIPTION
This PR adds support for `System.Text.Json.Nodes.JsonNode` as model.
It is similar to the `JsonElement` implementation, but allows e.g. for case insensitive lookup as described in https://github.com/Handlebars-Net/Handlebars.Net/discussions/491#discussioncomment-2156406