### PR TITLE
Update java to resolve SonarCloud scanner issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,10 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 3.1.201
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v4
         with:
-          java-version: '13' # The JDK version to make available on the path.
+          java-version: '21' # The JDK version to make available on the path.
+          distribution: 'zulu'
       - name: Cache SonarCloud packages
         uses: actions/cache@v1
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -56,9 +56,10 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 3.1.201
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v4
         with:
-          java-version: '13' # The JDK version to make available on the path.
+          java-version: '21' # The JDK version to make available on the path.
+          distribution: 'zulu'
       - name: Cache SonarCloud packages
         uses: actions/cache@v1
         with:


### PR DESCRIPTION
This bumps the java version for SonarCloud so that the pipelines resumes working and enables the other PR's to be merged